### PR TITLE
MNT: Re-rendered with conda-build 3.17.8, conda-smithy 3.2.13, and co…

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -10,11 +10,15 @@ docker_image:
 - condaforge/linux-anvil-comp7
 freetype:
 - 2.9.1
+librsvg:
+- 2.44.3
 libtiff:
 - 4.0.9
 pin_run_as_build:
   freetype:
     max_pin: x
+  librsvg:
+    max_pin: x.x
   libtiff:
     max_pin: x
   zlib:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -10,6 +10,8 @@ cxx_compiler:
 - clangxx
 freetype:
 - 2.9.1
+librsvg:
+- 2.44.3
 libtiff:
 - 4.0.9
 macos_machine:
@@ -19,6 +21,8 @@ macos_min_version:
 pin_run_as_build:
   freetype:
     max_pin: x
+  librsvg:
+    max_pin: x.x
   libtiff:
     max_pin: x
   zlib:


### PR DESCRIPTION
…nda-forge-pinning 2019.02.11

This adds a needed pinning for librsvg.